### PR TITLE
fix: support h3 v1 and v2 in cache-control server plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "@nuxt/kit": "^4.0.1",
     "defu": "^6.1.4"
   },
+  "peerDependencies": {
+    "h3": ">=1"
+  },
   "devDependencies": {
     "@nuxt/devtools": "^2.6.2",
     "@nuxt/eslint-config": "^1.7.0",
@@ -49,6 +52,7 @@
     "@types/node": "^24.1.0",
     "changelogen": "^0.6.2",
     "eslint": "^9.31.0",
+    "h3": "^1.15.11",
     "nuxt": "^4.0.1",
     "vitest": "^3.2.4"
   },


### PR DESCRIPTION
## Problem

When a project uses a dependency that brings in `h3@2.x` (e.g. `nuxt-schema-org ≥ 6.2.0` via its devtools layer), pnpm hoists `h3@2` to the root `node_modules`. Since `nuxt-cache-control` did not declare `h3` as a peer dependency, pnpm resolved the import to this hoisted `h3@2` instead of Nuxt's `h3@1`.

`h3@2`'s `getQuery()` constructs a full URL internally via `getRequestURL()`, which requires a valid `host` header:

```js
// h3 v2 internals
return new URL(event.path, `${protocol}://${host}`)
```

Nuxt's synthetic internal error requests (`/__nuxt_error?url=…&statusCode=500`) do not carry a `host` header, so `new URL(path, 'http://undefined')` throws `Invalid URL` — crashing the server on every page load.

## Fix

Declare `h3` as a peer dependency:

```json
"peerDependencies": { "h3": ">=1" }
```

pnpm now always resolves h3 from the host project (Nuxt ships h3@1), not from a transitive devtools dependency. `h3` is also added to `devDependencies` so the playground and tests keep a concrete version.

## Reproduction

Install `nuxt-schema-org@6.2.0` alongside `@rezo-zero/nuxt-cache-control` in a Nuxt 4 project. Starting `pnpm dev` crashes immediately with:

```
Error: Invalid URL
  at new URL (node:internal/url:819:25)
  at getQuery (h3@2.0.1-rc.22/.../h3.mjs:584:34)
  at cache-control.js:5:15
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)