### PR TITLE
fix: replace getQuery with getRequestURL for h3 v1/v2 compatibility

### DIFF
--- a/src/runtime/server/plugins/cache-control.ts
+++ b/src/runtime/server/plugins/cache-control.ts
@@ -1,5 +1,5 @@
 import type { CacheControlOptions } from '~/src/runtime/composables/use-cache-control'
-import { getResponseStatus, setResponseHeader, getQuery, parseCookies } from 'h3'
+import { getResponseStatus, setResponseHeader, getRequestURL, parseCookies } from 'h3'
 import type { NitroApp } from 'nitropack'
 import { useRuntimeConfig } from '#imports'
 
@@ -10,7 +10,7 @@ import { useRuntimeConfig } from '#imports'
  */
 export default (nitroApp: NitroApp) => {
   nitroApp.hooks.hook('render:response', (_response, { event }) => {
-    const qs = getQuery(event)
+    const qs = Object.fromEntries(getRequestURL(event).searchParams)
 
     if (getResponseStatus(event) !== 200) {
       setResponseHeader(event, 'Cache-Control', `private, no-cache, no-store, must-revalidate`)


### PR DESCRIPTION
## Problem

`getQuery(event)` from h3 has a **breaking API change between h3@1 and h3@2** that this package exposes via its `h3: '>=1'` peer dependency.

**h3@1** reads `event.path` (a relative path string):
```js
function getQuery(event) {
  return getQuery$1(event.path || "");
}
```

**h3@2** attempts to construct an absolute `URL` object:
```js
function getQuery(event) {
  return parseQuery((event.url || new URL(event.req.url)).search.slice(1));
}
```

In a Nitro context running h3@1, `event.url` is `undefined` and `event.req.url` is a **relative path** like `/`. Calling `new URL('/')` throws:

```
TypeError: Invalid URL
  at new URL (node:internal/url:819:25)
  at getQuery (h3@2.0.1-rc.22/dist/h3.mjs:584:34)
  at nuxt-cache-control/dist/runtime/server/plugins/cache-control.js:5:15
```

This happens when `@nuxt/eslint` (via `@eslint/config-inspector` → `devframe`) brings `h3@2` into the pnpm dependency tree — pnpm then resolves `nuxt-cache-control`'s `h3: '>=1'` peer to `h3@2`, causing every server-rendered page to crash.

## Fix

Replace `getQuery(event)` with `Object.fromEntries(getRequestURL(event).searchParams)`.

`getRequestURL(event)` is available in **both** h3@1 and h3@2 and always returns a valid absolute `URL` object (it uses the request host as base, so `new URL('/', 'http://localhost')` is always valid). The resulting `searchParams` object, converted to a plain object via `Object.fromEntries`, has the same shape as what `getQuery` returned — no call-site changes needed.

## Diff

```diff
-import { getResponseStatus, setResponseHeader, getQuery, parseCookies } from 'h3'
+import { getResponseStatus, setResponseHeader, getRequestURL, parseCookies } from 'h3'

-    const qs = getQuery(event)
+    const qs = Object.fromEntries(getRequestURL(event).searchParams)
```

## Why not constrain the peer dep to `>=1.15.11 <2` ?

Restricting the peer range to exclude h3@2 does not fully prevent the crash: pnpm's strict peer resolution can still resolve this package's peer to h3@2 when another dependency (e.g. `@nuxt/eslint`) brings it into the tree, potentially creating two h3 instances. It would also exclude future Nuxt versions that ship h3@2 stable. `getRequestURL` is the stable cross-version API and the right abstraction layer to use.

Fixes: `[request error] [unhandled] TypeError: Invalid URL` on every SSR request when this package is peer-resolved against h3@2.